### PR TITLE
Fix image stretch in webkit

### DIFF
--- a/contactus.php
+++ b/contactus.php
@@ -23,7 +23,9 @@
                 <h3 class="mb-5">Or contact us directly</h3>
                 <div class="col-lg-3 col-sm-6 col-12 mb-3">
                     <div class="card px-3 h-100">
+                        <div class="partner-logo-div">
                         <img src="<?php echo wp_get_attachment_url(get_theme_mod('intact-contacts-box1-image')) ?>" class="card-img-top pt-4 px-3 mt-3" alt="...">
+                        </div>
                         <div class="card-body px-3 pb-4">
                             <h6><?php echo get_theme_mod('intact-contacts-box1-title') ?></h6>
                             <p class="card-text"><?php echo get_theme_mod('intact-contacts-box1-text') ?></p>
@@ -32,7 +34,9 @@
                 </div>
                 <div class="col-lg-3 col-sm-6 col-12 mb-3">
                     <div class="card px-3 h-100">
+                        <div class="partner-logo-div">
                         <img src="<?php echo wp_get_attachment_url(get_theme_mod('intact-contacts-box2-image')) ?>" class="card-img-top pt-4 px-3 mt-3" alt="...">
+                        </div>
                         <div class="card-body px-3 pb-4">
                             <h6><?php echo get_theme_mod('intact-contacts-box2-title') ?></h6>
                             <p class="card-text mb-0"><?php echo get_theme_mod('intact-contacts-box2-text') ?></p>
@@ -41,7 +45,9 @@
                 </div>
                 <div class="col-lg-3 col-sm-6 col-12 mb-3">
                     <div class="card px-3 h-100">
+                        <div class="partner-logo-div">
                         <img src="<?php echo wp_get_attachment_url(get_theme_mod('intact-contacts-box3-image')) ?>" class="card-img-top pt-4 px-3 mt-3" alt="...">
+                        </div>
                         <div class="card-body px-3 pb-4">
                             <h6><?php echo get_theme_mod('intact-contacts-box3-title') ?></h6>
                             <p class="card-text mb-0"><?php echo get_theme_mod('intact-contacts-box3-text') ?></p>
@@ -50,7 +56,9 @@
                 </div>
                 <div class="col-lg-3 col-sm-6 col-12 mb-3">
                     <div class="card px-3 h-100">
+                        <div class="partner-logo-div">
                         <img src="<?php echo wp_get_attachment_url(get_theme_mod('intact-contacts-box4-image')) ?>" class="card-img-top pt-4 px-3 mt-3" alt="...">
+                        </div>
                         <div class="card-body px-3 pb-4">
                             <h6><?php echo get_theme_mod('intact-contacts-box4-title') ?></h6>
                             <p class="card-text mb-0"><?php echo get_theme_mod('intact-contacts-box4-text') ?></p>

--- a/style.css
+++ b/style.css
@@ -418,3 +418,8 @@ body#wpadminbar .fixed-top{
     border: 1px solid #ced4da;
     transition: border-color .15s ease-in-out,box-shadow .15s ease-in-out;
 }
+
+.partner-logo-div {
+    display: flex;
+    align-items: flex-start;
+}


### PR DESCRIPTION
Fixed logo image stretch in "Contact us" page that appeared on webkit browsers.